### PR TITLE
fix: DMRId to []string

### DIFF
--- a/data/data.go
+++ b/data/data.go
@@ -19,7 +19,7 @@ type HamCall struct {
 	FileNumber string    `json:"file_number"`
 	LOTW       string    `json:"last_lotw"`
 	LicenseKey string    `json:"license_key"`
-	DMRID      []int     `json:"dmr_id,omitempty"`
+	DMRID      []string     `json:"dmr_id,omitempty"`
 	Location   *Location `json:"location,omitempty"`
 }
 

--- a/data/data.go
+++ b/data/data.go
@@ -19,7 +19,7 @@ type HamCall struct {
 	FileNumber string    `json:"file_number"`
 	LOTW       string    `json:"last_lotw"`
 	LicenseKey string    `json:"license_key"`
-	DMRID      []string     `json:"dmr_id,omitempty"`
+	DMRID      []string  `json:"dmr_id,omitempty"`
 	Location   *Location `json:"location,omitempty"`
 }
 

--- a/source/radioid/radioid.go
+++ b/source/radioid/radioid.go
@@ -56,11 +56,11 @@ func Process(calls *map[string]data.HamCall) {
 		call := record[1]
 		item, c := (*calls)[call]
 		if c {
-			item.DMRID = append(item.DMRID, id)
+			item.DMRID = append(item.DMRID, strconv.Itoa(id))
 		} else {
 			item = data.HamCall{
 				Callsign: call,
-				DMRID:    []int{id},
+				DMRID:    []string{strconv.Itoa(id)},
 			}
 
 		}


### PR DESCRIPTION
Currently the .json version of a Hamcall search returns all numbers as strings except DMR IDs which are a (for the struct version) a slice of ints.

This PR is to make this formatting more consistent by returning the DMR ID as a slice of strings, allowing the end-user to convert as needed.

Pretty new to Golang, so let me know if this isn't the best way to go about this, or if I should change anything up. Happy to do so.