### PR TITLE
Import canada callsigns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@ amat
 .env
 counts
 main
+ised_data
 hamcall.db

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ import (
 	"github.com/pcunning/hamcall/b2"
 	"github.com/pcunning/hamcall/data"
 	"github.com/pcunning/hamcall/source/geo"
+	"github.com/pcunning/hamcall/source/ised"
 	"github.com/pcunning/hamcall/source/lotw"
 	"github.com/pcunning/hamcall/source/radioid"
 	"github.com/pcunning/hamcall/source/uls"
@@ -86,9 +87,10 @@ func main() {
 func downloadFiles() {
 	var wg sync.WaitGroup
 
-	wg.Add(4)
+	wg.Add(5)
 
 	go uls.Download(&wg)
+	go ised.Download(&wg)
 	go radioid.Download(&wg)
 	go lotw.Download(&wg)
 	go geo.Download(&wg)
@@ -98,6 +100,7 @@ func downloadFiles() {
 
 func process(calls *map[string]data.HamCall) {
 	uls.Process(calls)
+	ised.Process(calls, "ised_data/amateur_delim.txt")
 	radioid.Process(calls)
 	lotw.Process(calls)
 	geo.Process(calls)
@@ -122,9 +125,12 @@ func cli(calls *map[string]data.HamCall) {
 	validate := func(input string) error {
 		var usCall = regexp.MustCompile(`^[AKNW][A-Z]{0,2}[0123456789][A-Z]{1,3}$`)
 
-		if !usCall.MatchString(strings.ToUpper(input)) {
+		var caCall = regexp.MustCompile(`^(?:VE|VA|VB)[0123456789][A-Z]{1,3}$`)
+
+		if !usCall.MatchString(strings.ToUpper(input)) && !caCall.MatchString(strings.ToUpper(input)) {
 			return errors.New("Invalid callsign")
 		}
+
 		return nil
 	}
 

--- a/source/ised/ised.go
+++ b/source/ised/ised.go
@@ -1,0 +1,90 @@
+package ised
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/pcunning/hamcall/data"
+	"github.com/pcunning/hamcall/downloader"
+)
+
+func Download(wg *sync.WaitGroup) (string, error) {
+	defer wg.Done()
+	fmt.Println("Downloading ISED (Canada) data")
+	err := downloader.FetchHttp("ised.zip", "https://apc-cap.ic.gc.ca/datafiles/amateur_delim.zip")
+	if err != nil {
+		log.Fatalf("Error downloading ISED (Canada) data: %v", err)
+	}
+
+	_, err = downloader.Unzip("ised.zip", "ised_data")
+	if err != nil {
+		log.Fatalf("Error unzipping ISED (Canada) data: %v", err)
+	}
+
+	return "ised_data/amateur_delim.txt", nil
+}
+
+func ProcessLine(line string) data.HamCall {
+	columns := strings.Split(line, ";")
+	var item data.HamCall
+	if columns[0] != "callsign" {
+		var class string
+		switch {
+		case columns[7] != "" && columns[11] == "":
+			class = "Basic"
+		case columns[11] != "" && columns[10] == "":
+			class = "Basic with Honors"
+		case columns[10] != "":
+			class = "Advanced"
+		default:
+			class = "Unknown"
+		}
+		if columns[9] != "" || columns[8] != "" {
+			class += " (w/ Morse)"
+		}
+		name := columns[1] + " " + columns[2]
+		item = data.HamCall{
+			Callsign:  columns[0],
+			Name:      name,
+			FirstName: columns[1],
+			LastName:  columns[2],
+			Address:   columns[3],
+			City:      columns[4],
+			State:     columns[5],
+			Zip:       columns[6],
+			Class:     class,
+		}
+	}
+	return item
+}
+
+func Process(calls *map[string]data.HamCall, path string) {
+	start := time.Now()
+	fmt.Print("processing ISED data")
+
+	// Step 2: Open the new file.
+	f, err := os.Open(path)
+	if err != nil {
+		fmt.Println(err)
+		return
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+
+	var line string
+	var call data.HamCall
+
+	// Step 3: Process Each Line.
+	for scanner.Scan() {
+		line = scanner.Text()
+		call = ProcessLine(line)
+		(*calls)[call.Callsign] = call
+	}
+
+	fmt.Printf(" ... %s\n", time.Since(start).String())
+}

--- a/source/ised/ised_test.go
+++ b/source/ised/ised_test.go
@@ -1,0 +1,77 @@
+package ised
+
+import (
+	"testing"
+
+	"github.com/pcunning/hamcall/data"
+)
+
+func TestBasic(t *testing.T) {
+	line := "VA2TRW;Tripp;Sanders;;;QC;;A;;;;;;;;;;"
+	call := ProcessLine(line)
+
+	if call.Class != "Basic" {
+		t.Fatalf(`call.Class = %s, not 'Basic'`, call.Class)
+	}
+}
+
+func TestBasicWithHonors(t *testing.T) {
+	line := "VA2TRW;Tripp;Sanders;;;QC;;;;;;E;;;;;;"
+	call := ProcessLine(line)
+
+	if call.Class != "Basic with Honors" {
+		t.Fatalf(`call.Class = %s, not 'Basic With Honors'`, call.Class)
+	}
+}
+
+func TestAdvanced(t *testing.T) {
+	line := "VA2TRW;Tripp;Sanders;;;QC;;;;;D;;;;;;;"
+	call := ProcessLine(line)
+
+	if call.Class != "Advanced" {
+		t.Fatalf(`call.Class = %s, not 'Advanced'`, call.Class)
+	}
+}
+
+func TestWithMorse(t *testing.T) {
+	var line string
+	var call data.HamCall
+
+	line = "VA2TRW;Tripp;Sanders;;;QC;;A;B;;;;;;;;;"
+	call = ProcessLine(line)
+
+	if call.Class != "Basic (w/ Morse)" {
+		t.Fatalf(`call.Class = %s, not 'Basic (w/ Morse)'`, call.Class)
+	}
+
+	line = "VA2TRW;Tripp;Sanders;;;QC;;;B;;;E;;;;;;"
+	call = ProcessLine(line)
+
+	if call.Class != "Basic with Honors (w/ Morse)" {
+		t.Fatalf(`call.Class = %s, not 'Basic with Honors (w/ Morse)'`, call.Class)
+	}
+
+	line = "VA2TRW;Tripp;Sanders;;;QC;;;B;;D;;;;;;;"
+	call = ProcessLine(line)
+
+	if call.Class != "Advanced (w/ Morse)" {
+		t.Fatalf(`call.Class = %s, not 'Advanced (w/ Morse)'`, call.Class)
+	}
+}
+
+func TestFileImport(t *testing.T) {
+	calls := make(map[string]data.HamCall)
+	Process(&calls, "./ised_test_data.txt")
+
+	if len(calls) != 5 {
+		t.Fatalf(`len(calls) = %d, not 5`, len(calls))
+	}
+
+	if calls["VA4AAA"].State != "MB" {
+		t.Fatalf(`call.State = %s, not 'MB'`, calls["VA4AAA"].State)
+	}
+
+	if calls["VA4AAA"].Class != "Advanced (w/ Morse)" {
+		t.Fatalf(`call.Class = %s, not 'Advanced (w/ Morse)'`, calls["VA4AAA"].Class)
+	}
+}

--- a/source/ised/ised_test_data.txt
+++ b/source/ised/ised_test_data.txt
@@ -1,0 +1,5 @@
+VA2AAA;John;Doe;;;QC;;;;;;E;;;;;;
+VA1AAA;John;Doe;;;NS;;;;;;E;;;;;;
+VA4AAA;John;Doe;;;MB;;;B;;D;E;;;;;;
+VA3AAA;John;Doe;;;ON;;;;;D;E;;;;;;
+VE2AAA;John;Doe;;;QC;;;;;D;E;;;;;;


### PR DESCRIPTION
This PR imports Canadian callsigns as provided by ISED in comma-delimited .txt format.